### PR TITLE
Update install-config.yaml

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -14,7 +14,7 @@ networking:
   clusterNetwork:
     - cidr: 10.128.0.0/14
       hostPrefix: 23
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
     - 172.30.0.0/16
 platform:


### PR DESCRIPTION
For OCP 4.15.0, the networkType changes to OVNKubernetes .